### PR TITLE
adapted binding to use nan for cross-version compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules/
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: node_js
 node_js:
+  - "0.8"
   - "0.10"
   - "0.11"
+install:
+  - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
+  - "npm install npm"
+  - "./node_modules/.bin/npm install"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An [xxhash](http://code.google.com/p/xxhash/) binding for [node.js](http://nodej
 
 ## Installation
 
-You must be running node 0.8 or later.
+You must be running node 0.8 or later. (Thanks to an npm 2.0 compatibility issue, travis tests fail on 0.8.)
 
   npm install xxhash
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,21 @@
-
-Description
-===========
+# xxhash-nan
 
 An [xxhash](http://code.google.com/p/xxhash/) binding for [node.js](http://nodejs.org/).
 
+Forked from the [original]() to add compatibility with future versions of node via NAN.
 
-Requirements
-============
+## Installation
 
-* [node.js](http://nodejs.org/) -- v0.6.0 or newer
+You must be running node 0.10 or later.
 
+  npm install xxhash
 
-Install
-============
-
-    npm install xxhash
-
-
-Examples
-========
+## Examples
 
 * Hash a file in one step:
 
 ```javascript
-var XXHash = require('xxhash'),
+var XXHash = require('xxhash-nan'),
     fs = require('fs');
 
 var file = fs.readFileSync('somefile'),
@@ -33,7 +25,7 @@ var file = fs.readFileSync('somefile'),
 * Hash a file in steps:
 
 ```javascript
-var XXHash = require('xxhash'),
+var XXHash = require('xxhash-nan'),
     fs = require('fs');
 
 var hasher = new XXHash(0xCAFEBABE);

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # xxhash-nan
 
-An [xxhash](http://code.google.com/p/xxhash/) binding for [node.js](http://nodejs.org/).
+An [xxhash](http://code.google.com/p/xxhash/) binding for [node.js](http://nodejs.org/). Forked from the [original](https://github.com/mscdex/node-xxhash) to add compatibility with future versions of node via NAN.
 
-Forked from the [original]() to add compatibility with future versions of node via NAN.
+[![on npm](http://img.shields.io/npm/v/xxhash-nan.svg?style=flat)](https://www.npmjs.org/package/jthoober)  [![Tests](http://img.shields.io/travis/ceejbot/xxhash-nan.svg?style=flat)](http://travis-ci.org/ceejbot/xxhash-nan)    [![Dependencies](http://img.shields.io/david/ceejbot/xxhash-nan.svg?style=flat)](https://david-dm.org/ceejbot/xxhash-nan)
 
 ## Installation
 
@@ -22,7 +22,7 @@ var file = fs.readFileSync('somefile'),
     result = XXHash.hash(file, 0xCAFEBABE);
 ```
 
-* Hash a file in steps:
+Hash a file incrementally:
 
 ```javascript
 var XXHash = require('xxhash-nan'),

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An [xxhash](http://code.google.com/p/xxhash/) binding for [node.js](http://nodej
 
 ## Installation
 
-You must be running node 0.10 or later.
+You must be running node 0.8 or later.
 
   npm install xxhash
 
@@ -39,18 +39,14 @@ fs.createReadStream('somefile')
   });
 ```
 
+## API
 
-API
-===
-
-XXHash Static Methods
----------------------
+### XXHash module functions
 
 * **hash**(< _Buffer_ >data, < _integer_ >seed) - _integer_ - Performs a single/one-time hash of `data` with the given `seed`. The resulting hash is returned.
 
 
-XXHash Methods
---------------
+### XXHash Methods
 
 * **(constructor)**(< _Integer_ >seed) - Create and return a new Hash instance that uses the given `seed`.
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,7 @@
   'targets': [
     {
       'target_name': 'hash',
-      'include_dirs': [ 'deps/xxhash' ],
+      'include_dirs': [ 'deps/xxhash', "<!(node -e \"require('nan')\")" ],
       'sources': [
         'src/hash.cc',
         'deps/xxhash/xxhash.h',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xxhash-nan",
   "description": "xxhash bindings for node.js, using nan for portability",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "author": "C J Silverio <ceejceej@gmail.com>",
   "bugs": {
     "url": "https://github.com/ceejbot/xxhash-nan/issues"

--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   "repository": { "type": "git", "url": "https://github.com/mscdex/node-xxhash.git" },
   "scripts": { "test": "mocha -R spec test/test*.js" },
   "dependencies": { "nan": "~0.7.0" },
-  "devDependencies": { "mocha": "*", "must": "*", "node-gyp": "*" }
+  "devDependencies": { "mocha": "*", "must": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,40 @@
-{ "name": "xxhash",
-  "version": "0.3.0",
-  "author": "Brian White <mscdex@mscdex.net>",
-  "description": "An xxhash binding for node.js",
+{
+  "name": "xxhash-nan",
+  "description": "xxhash bindings for node.js, using nan for portability",
+  "version": "1.0.0",
+  "author": "C J Silverio <ceejceej@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/ceejbot/xxhash-nan/issues"
+  },
+  "contributors": [
+    "Brian White <mscdex@mscdex.net>",
+    "C J Silverio <ceejceej@gmail.com>"
+  ],
+  "dependencies": {
+    "nan": "~0.7.0"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "must": "*"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "homepage": "https://github.com/ceejbot/xxhash-nan",
+  "keywords": [
+    "hash",
+    "xxhash",
+    "non-cryptographic hash",
+    "hashing",
+    "streaming hash"
+  ],
+  "license": "MIT",
   "main": "./lib/xxhash",
-  "engines": { "node" : ">=0.6.0" },
-  "keywords": [ "hash", "xxhash", "fast", "streaming" ],
-  "licenses": [ { "type": "MIT", "url": "https://raw.github.com/mscdex/node-xxhash/master/LICENSE" } ],
-  "repository": { "type": "git", "url": "https://github.com/mscdex/node-xxhash.git" },
-  "scripts": { "test": "mocha -R spec test/test*.js" },
-  "dependencies": { "nan": "~0.7.0" },
-  "devDependencies": { "mocha": "*", "must": "*" }
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ceejbot/xxhash-nan.git"
+  },
+  "scripts": {
+    "test": "mocha -R spec test/test*.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 { "name": "xxhash",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "An xxhash binding for node.js",
   "main": "./lib/xxhash",
   "engines": { "node" : ">=0.6.0" },
   "keywords": [ "hash", "xxhash", "fast", "streaming" ],
   "licenses": [ { "type": "MIT", "url": "https://raw.github.com/mscdex/node-xxhash/master/LICENSE" } ],
-  "repository": { "type": "git", "url": "https://github.com/mscdex/node-xxhash.git" }
+  "repository": { "type": "git", "url": "https://github.com/mscdex/node-xxhash.git" },
+  "dependencies": { "nan": "~0.7.0" }
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "C J Silverio <ceejceej@gmail.com>"
   ],
   "dependencies": {
-    "nan": "~0.7.0"
+    "nan": "~1.3.0"
   },
   "devDependencies": {
-    "mocha": "*",
-    "must": "*"
+    "mocha": "~1.21.4",
+    "must": "~0.12.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -7,5 +7,7 @@
   "keywords": [ "hash", "xxhash", "fast", "streaming" ],
   "licenses": [ { "type": "MIT", "url": "https://raw.github.com/mscdex/node-xxhash/master/LICENSE" } ],
   "repository": { "type": "git", "url": "https://github.com/mscdex/node-xxhash.git" },
-  "dependencies": { "nan": "~0.7.0" }
+  "scripts": { "test": "mocha -R spec test/test*.js" },
+  "dependencies": { "nan": "~0.7.0" },
+  "devDependencies": { "mocha": "*", "must": "*", "node-gyp": "*" }
 }

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -38,7 +38,7 @@ class Hash : public node::ObjectWrap {
       Hash* obj = new Hash(args[0]->Uint32Value());
       obj->Wrap(args.This());
 
-      return args.This();
+      NanReturnValue(args.This());
     }
 
     static NAN_METHOD(Update) {

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -45,6 +45,11 @@ class Hash : public node::ObjectWrap {
       NanScope();
       Hash* obj = ObjectWrap::Unwrap<Hash>(args.This());
 
+      if (!obj->state) {
+        ThrowException(Exception::TypeError(String::New("cannot call update after digest")));
+        NanReturnUndefined();
+      }
+
       if (!node::Buffer::HasInstance(args[0])) {
         ThrowException(Exception::TypeError(String::New("data argument must be a Buffer")));
         NanReturnUndefined();

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -113,21 +113,20 @@ class Hash : public node::ObjectWrap {
       NanReturnValue(Integer::NewFromUnsigned(result));
     }
 
-
     static void Initialize(Handle<Object> target) {
       NanScope();
 
       v8::Local<v8::FunctionTemplate> tpl = v8::FunctionTemplate::New(NewInstance);
-      Local<String> name = NanSymbol("XXHash");
+      Local<String> name = NanNew<String>("XXHash");
 
-      NanAssignPersistent(v8::FunctionTemplate, constructor, tpl);
+      NanAssignPersistent(constructor, tpl);
       tpl->SetClassName(name);
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
       NODE_SET_PROTOTYPE_METHOD(tpl, "update", Update);
       NODE_SET_PROTOTYPE_METHOD(tpl, "digest", Digest);
 
-      tpl->Set(NanSymbol("hash"), FunctionTemplate::New(StaticHash)->GetFunction());
+      tpl->Set(NanNew<String>("hash"), FunctionTemplate::New(StaticHash)->GetFunction());
 
       target->Set(name, tpl->GetFunction());
     }

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -47,6 +47,7 @@ class Hash : public node::ObjectWrap {
 
       if (!node::Buffer::HasInstance(args[0])) {
         ThrowException(Exception::TypeError(String::New("data argument must be a Buffer")));
+        NanReturnUndefined();
       }
 
 #if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION < 10
@@ -58,6 +59,7 @@ class Hash : public node::ObjectWrap {
       size_t buflen = node::Buffer::Length(data);
       if (buflen > 2147483647 || buflen == 0) {
         ThrowException(Exception::TypeError(String::New("data length must be 0 < n <= 2147483647")));
+        NanReturnUndefined();
       }
 
       XXH32_feed(obj->state, node::Buffer::Data(data), buflen);

--- a/test/test-01.js
+++ b/test/test-01.js
@@ -1,0 +1,92 @@
+/*global describe:true, it:true, before:true, after:true */
+
+var demand = require('must');
+var XXHash = require('../lib/xxhash');
+
+var seed = 0xcafed00d;
+
+describe('XXHash', function()
+{
+	it('requires a seed passed to its constructor', function()
+	{
+		function shouldThrow() { return new XXHash(); }
+		shouldThrow.must.throw(/Expected unsigned integer seed argument/);
+	});
+
+	it('can be constructed', function()
+	{
+		var hasher = new XXHash(seed);
+		hasher.must.be.an(XXHash);
+	});
+
+	it('has an update() method', function()
+	{
+		var hasher = new XXHash(seed);
+		hasher.must.have.property('update');
+		hasher.update.must.be.a.function();
+	});
+
+	it('update() requires a buffer argument', function()
+	{
+		function shouldThrow()
+		{
+			var hasher = new XXHash(seed);
+			// hasher.update('foo');
+		}
+
+		shouldThrow.must.throw(/data argument must be a Buffer/);
+	});
+
+	it('update() can be called repeatedly', function()
+	{
+		var hasher = new XXHash(seed);
+		hasher.update(new Buffer('foo'));
+		hasher.update(new Buffer('bar'));
+	});
+
+	it('has a digest() method', function()
+	{
+		var hasher = new XXHash(seed);
+		hasher.must.have.property('digest');
+		hasher.digest.must.be.a.function();
+	});
+
+	it('returns an integer from digest()', function()
+	{
+		var hasher = new XXHash(seed);
+		hasher.update(new Buffer('foo'));
+		var result = hasher.digest();
+		result.must.be.a.number();
+	});
+
+	function hashHelper(input)
+	{
+		var hasher = new XXHash(seed);
+		hasher.update(new Buffer(input));
+		return hasher.digest();
+	}
+
+	it('hashes to the expected results', function()
+	{
+		var inputs = [ 'bar', 'coatis have long tails'];
+		var results = [ 2370523005, 1792348589];
+
+		for (var i = 0; i < inputs.length; i++)
+			hashHelper(inputs[i]).must.equal(results[i]);
+	});
+
+	it('update() cannot be called after digest() has been called' /*, function()
+	{
+		// Original bindings just SIGSEGV here. Would be better to detect & throw instead.
+
+		function shouldThrow()
+		{
+			var hasher = new XXHash(seed);
+			hasher.update(new Buffer('foo'));
+			hasher.digest();
+			// hasher.update(new Buffer('bar'));
+		}
+
+		shouldThrow.must.throw();
+	} */);
+})

--- a/test/test-01.js
+++ b/test/test-01.js
@@ -31,7 +31,7 @@ describe('XXHash', function()
 		function shouldThrow()
 		{
 			var hasher = new XXHash(seed);
-			// hasher.update('foo');
+			hasher.update('foo');
 		}
 
 		shouldThrow.must.throw(/data argument must be a Buffer/);

--- a/test/test-hasher.js
+++ b/test/test-hasher.js
@@ -5,31 +5,25 @@ var XXHash = require('../lib/xxhash');
 
 var seed = 0xcafed00d;
 
-describe('XXHash', function()
-{
-	it('requires a seed passed to its constructor', function()
-	{
+describe('XXHash', function() {
+	it('requires a seed passed to its constructor', function() {
 		function shouldThrow() { return new XXHash(); }
 		shouldThrow.must.throw(/Expected unsigned integer seed argument/);
 	});
 
-	it('can be constructed', function()
-	{
+	it('can be constructed', function() {
 		var hasher = new XXHash(seed);
 		hasher.must.be.an(XXHash);
 	});
 
-	it('has an update() method', function()
-	{
+	it('has an update() method', function() {
 		var hasher = new XXHash(seed);
 		hasher.must.have.property('update');
 		hasher.update.must.be.a.function();
 	});
 
-	it('update() requires a buffer argument', function()
-	{
-		function shouldThrow()
-		{
+	it('update() requires a buffer argument', function() {
+		function shouldThrow() {
 			var hasher = new XXHash(seed);
 			hasher.update('foo');
 		}
@@ -37,48 +31,42 @@ describe('XXHash', function()
 		shouldThrow.must.throw(/data argument must be a Buffer/);
 	});
 
-	it('update() can be called repeatedly', function()
-	{
+	it('update() can be called repeatedly', function() {
 		var hasher = new XXHash(seed);
 		hasher.update(new Buffer('foo'));
 		hasher.update(new Buffer('bar'));
 	});
 
-	it('has a digest() method', function()
-	{
+	it('has a digest() method', function() {
 		var hasher = new XXHash(seed);
 		hasher.must.have.property('digest');
 		hasher.digest.must.be.a.function();
 	});
 
-	it('returns an integer from digest()', function()
-	{
+	it('returns an integer from digest()', function() {
 		var hasher = new XXHash(seed);
 		hasher.update(new Buffer('foo'));
 		var result = hasher.digest();
 		result.must.be.a.number();
 	});
 
-	function hashHelper(input)
-	{
+	function hashHelper(input) {
 		var hasher = new XXHash(seed);
 		hasher.update(new Buffer(input));
 		return hasher.digest();
 	}
 
-	it('hashes to the expected results', function()
-	{
+	it('hashes to the expected results', function() {
 		var inputs = [ 'bar', 'coatis have long tails'];
 		var results = [ 2370523005, 1792348589];
 
-		for (var i = 0; i < inputs.length; i++)
+		for (var i = 0; i < inputs.length; i++) {
 			hashHelper(inputs[i]).must.equal(results[i]);
+    }
 	});
 
-	it('update() cannot be called after digest() has been called', function()
-	{
-		function shouldThrow()
-		{
+	it('update() cannot be called after digest() has been called', function() {
+		function shouldThrow() {
 			var hasher = new XXHash(seed);
 			hasher.update(new Buffer('foo'));
 			hasher.digest();
@@ -87,4 +75,4 @@ describe('XXHash', function()
 
 		shouldThrow.must.throw(/cannot call update after digest/);
 	});
-})
+});

--- a/test/test-hasher.js
+++ b/test/test-hasher.js
@@ -75,18 +75,16 @@ describe('XXHash', function()
 			hashHelper(inputs[i]).must.equal(results[i]);
 	});
 
-	it('update() cannot be called after digest() has been called' /*, function()
+	it('update() cannot be called after digest() has been called', function()
 	{
-		// Original bindings just SIGSEGV here. Would be better to detect & throw instead.
-
 		function shouldThrow()
 		{
 			var hasher = new XXHash(seed);
 			hasher.update(new Buffer('foo'));
 			hasher.digest();
-			// hasher.update(new Buffer('bar'));
+			hasher.update(new Buffer('bar'));
 		}
 
-		shouldThrow.must.throw();
-	} */);
+		shouldThrow.must.throw(/cannot call update after digest/);
+	});
 })


### PR DESCRIPTION
This change or something like it is required for the module to work with node 0.11 and therefore 0.12, thanks to V8 API changes.

- Added a dependency on [nan](https://github.com/rvagg/nan).
- Adapted the bindings to use nan macros to smooth over V8 api changes.
- Added a check in update() to see if it's called after digest, so we throw an exception instead of crashing.
- Wrote a small set of mocha unit tests so I could be satisfied that the bindings were working properly after being changed.
- Added a .travis.yml file for automated testing.

The Travis 0.11 build is failing for unrelated reasons, I believe. You can use [nvm](https://github.com/brianloveswords/nvm) to install 0.11.9 and test by hand.