### PR TITLE
Use Nan::SetMethod

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An xxhash binding for node.js",
   "main": "./lib/xxhash",
   "dependencies": {
-    "nan": "^2.0.9"
+    "nan": "^2.3.1"
   },
   "scripts": {
     "install": "node-gyp rebuild",

--- a/src/hash_32.hpp
+++ b/src/hash_32.hpp
@@ -153,9 +153,7 @@ class Hash32 : public node::ObjectWrap {
 
       Nan::SetPrototypeMethod(tpl, "update", Update);
       Nan::SetPrototypeMethod(tpl, "digest", Digest);
-
-      tpl->Set(Nan::New<String>("hash").ToLocalChecked(),
-               Nan::New<FunctionTemplate>(StaticHash)->GetFunction());
+      Nan::SetMethod(tpl, "hash", StaticHash);
       target->Set(name, tpl->GetFunction());
 
       constructor_32.Reset(tpl);

--- a/src/hash_64.hpp
+++ b/src/hash_64.hpp
@@ -154,8 +154,7 @@ class Hash64 : public node::ObjectWrap {
       Nan::SetPrototypeMethod(tpl, "update", Update);
       Nan::SetPrototypeMethod(tpl, "digest", Digest);
 
-      tpl->Set(Nan::New<String>("hash").ToLocalChecked(),
-               Nan::New<FunctionTemplate>(StaticHash)->GetFunction());
+      Nan::SetMethod(tpl, "hash", StaticHash);
       target->Set(name, tpl->GetFunction());
 
       constructor_64.Reset(tpl);


### PR DESCRIPTION
In node 6.x I'm getting this warning message:
```
(node) v8::FunctionTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.
```

Nan already fixed this issue in https://github.com/nodejs/nan/commit/a90951e9ea70fa1b3836af4b925322919159100e.

So, just using newer Nan API.