### PR TITLE
hash64 seed fixes + byte order consistency changes

### DIFF
--- a/src/hash_64.hpp
+++ b/src/hash_64.hpp
@@ -18,11 +18,13 @@ class Hash64 : public node::ObjectWrap {
     static Local<Value> convert_result(uint64_t result, node::encoding enc) {
       // Use node::Encode() directly instead of Nan::Encode() because of missing
       // optimizations in Nan::Encode() for node v0.11+
+      char result_char[8];
+      convert_result_val(result, result_char);
       return node::Encode(
 #if NODE_MAJOR_VERSION > 0 || NODE_MINOR_VERSION > 10
                           Isolate::GetCurrent(),
 #endif
-                          reinterpret_cast<const char*>(&result),
+                          result_char,
                           sizeof(uint64_t),
                           enc);
     }
@@ -34,7 +36,7 @@ class Hash64 : public node::ObjectWrap {
         result_val = enc_val;
         if (node::Buffer::Length(result_val) >= sizeof(uint64_t)) {
           char* out_buf = node::Buffer::Data(result_val);
-          *(reinterpret_cast<uint64_t*>(&out_buf[0])) = result;
+          convert_result_val(result, out_buf);
         } else
           Nan::ThrowError("Buffer argument too small");
       } else if (enc_val->IsString()) {
@@ -50,6 +52,13 @@ class Hash64 : public node::ObjectWrap {
         Nan::ThrowTypeError("argument must be a Buffer or string");
 
       return result_val;
+    }
+
+    static void convert_result_val(uint64_t val, char buf[4]) {
+      for (int ii = 0; ii < 8; ++ii) {
+        buf[7 - ii] = val & 0xff;
+        val >>= 8;
+      }
     }
 
     static uint64_t convert_seed(Local<Value> seed_val, bool &did_throw) {

--- a/src/hash_64.hpp
+++ b/src/hash_64.hpp
@@ -52,26 +52,26 @@ class Hash64 : public node::ObjectWrap {
       return result_val;
     }
 
-    static uint64_t convert_seed(Local<Value> seed_val) {
-      if (seed_val->IsUint32())
-        return seed_val->Uint32Value();
+    static uint64_t convert_seed(Local<Value> seed_val, bool &did_throw) {
+      if (seed_val->IsNumber())
+        return seed_val->IntegerValue();
       else if (node::Buffer::HasInstance(seed_val)) {
-        char* seed_buf = node::Buffer::Data(seed_val);
+        unsigned char* seed_buf = (unsigned char*)node::Buffer::Data(seed_val);
         size_t seed_buf_len = node::Buffer::Length(seed_val);
         uint8_t nb = (seed_buf_len > 8 ? 8 : seed_buf_len);
         if (nb == 0) {
-          seed_val.Clear();
+          did_throw = true;
           Nan::ThrowTypeError("seed Buffer must not be empty");
           return 0;
         }
-        uint32_t seed = 0;
+        uint64_t seed = 0;
         for (uint8_t i = 0; i < nb; ++i) {
           seed <<= 8;
-          seed += seed_buf[i];
+          seed |= seed_buf[i];
         }
         return seed;
       }
-      seed_val.Clear();
+      did_throw = true;
       Nan::ThrowTypeError("invalid seed argument");
       return 0;
     }
@@ -85,9 +85,10 @@ class Hash64 : public node::ObjectWrap {
       else if (info.Length() == 0)
         return Nan::ThrowTypeError("Missing seed argument");
 
-      uint64_t seed = convert_seed(info[0]);
-      if (seed == 0 && info[0].IsEmpty())
-        return info.GetReturnValue().SetUndefined();
+      bool did_throw = false;
+      uint64_t seed = convert_seed(info[0], did_throw);
+      if (did_throw)
+        return;
 
       Hash64* obj = new Hash64(seed);
       obj->Wrap(info.This());
@@ -127,9 +128,10 @@ class Hash64 : public node::ObjectWrap {
       else if (!node::Buffer::HasInstance(info[0]))
         return Nan::ThrowTypeError("data argument must be a Buffer");
 
-      uint64_t seed = convert_seed(info[1]);
-      if (seed == 0 && info[1].IsEmpty())
-        return info.GetReturnValue().SetUndefined();
+      bool did_throw = false;
+      uint64_t seed = convert_seed(info[1], did_throw);
+      if (did_throw)
+        return;
 
       Local<Value> data = info[0];
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,16 +14,16 @@ var input = new Buffer('hello');
       assert.strictEqual(hash, 2717969635);
     } else {
       assert(Buffer.isBuffer(hash));
-      assert.strictEqual(hash.toString('hex'), 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash.toString('hex'), '0c5badaa04926dcd');
     }
   },
   // Non-streaming hashing, custom encoding
   function(Hash, bits) {
     var hash = Hash.hash(input, SEED, 'hex');
     if (bits === 32) {
-      assert.strictEqual(hash, 'e3ec00a2');
+      assert.strictEqual(hash, 'a200ece3');
     } else {
-      assert.strictEqual(hash, 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash, '0c5badaa04926dcd');
     }
   },
   // Streaming hashing
@@ -36,7 +36,7 @@ var input = new Buffer('hello');
       assert.strictEqual(hash, 2717969635);
     } else {
       assert(Buffer.isBuffer(hash));
-      assert.strictEqual(hash.toString('hex'), 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash.toString('hex'), '0c5badaa04926dcd');
     }
   },
   // Streaming hashing, custom encoding
@@ -46,9 +46,9 @@ var input = new Buffer('hello');
     hash.update(input.slice(2));
     hash = hash.digest('hex');
     if (bits === 32) {
-      assert.strictEqual(hash, 'e3ec00a2');
+      assert.strictEqual(hash, 'a200ece3');
     } else {
-      assert.strictEqual(hash, 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash, '0c5badaa04926dcd');
     }
   },
   // Streaming (streams2+) hashing
@@ -61,7 +61,7 @@ var input = new Buffer('hello');
       assert.strictEqual(hash, 2717969635);
     } else {
       assert(Buffer.isBuffer(hash));
-      assert.strictEqual(hash.toString('hex'), 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash.toString('hex'), '0c5badaa04926dcd');
     }
   },
   // Streaming (streams2+) hashing, custom encoding
@@ -71,9 +71,9 @@ var input = new Buffer('hello');
     hash.end(input.slice(2));
     hash = hash.read();
     if (bits === 32) {
-      assert.strictEqual(hash, 'e3ec00a2');
+      assert.strictEqual(hash, 'a200ece3');
     } else {
-      assert.strictEqual(hash, 'cd6d9204aaad5b0c');
+      assert.strictEqual(hash, '0c5badaa04926dcd');
     }
   },
 ].forEach(function(t) {


### PR DESCRIPTION
Attached are 2 changes, one is pretty straight forward, the other is a breaking change but one I think needs to happen.

First is 6a183008e941a58e6810c4e5c52a59754d37dbb7:
convert_seed in the 64-bit version currently uses uint32_t. This was a no brainer.

Additionally included are changes to thrown exceptions. The `seed_val.Clear()` trick and later check to `info[0].IsEmpty()` never worked. Since you're passing a copy of the v8::Local<> you only clear the handle in the local scope. In the case that `convert_seed` throws, you still end up calculating a hash and then it just so happens that the correct exception is thrown anyway. I fixed that to correctly detect the exception and return early.

The second change is 21b13985ab4856e8a59dda99cb4185c27064ed29:
Right now when you pass a buffer in as a seed value you are converting it to an uint32_t or uint64_t using big-endian format (the loop where you do seed <<= 8). But then when you return the hash you cast it to a char\* and return that as-is. On x86 that will be little-endian, on other platforms it may be big-endian.

I updated the hash functions to always return the hash in big-endian format (which currently matches what convert_seed expects). Since it is not uncommon to calculate a hash, and then to use that hash as a seed for another hash the endianness should at least be internally consistent.

So with these changes we should expect the results of node-xxhash to be the same on all platforms, and using the result of hash as a seed for another hash to work as expected.
