### PR TITLE
Fix building on GCC 4.9.4

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,9 @@
   'targets': [
     {
       'target_name': 'hash',
+      'defines': [
+        '__USE_XOPEN2K8'
+      ],
       'include_dirs': [
         'deps/xxhash',
         'src',


### PR DESCRIPTION
Without this fix building on GCC v4.9.4 is failing with this error and a few others (uselocale-related):

```
/usr/include/bits/stdio.h: In function ‘__ssize_t getline(char**, size_t*, FILE*)’:
/usr/include/bits/stdio.h:118:52: error: ‘__getdelim’ was not declared in this scope
   return __getdelim (__lineptr, __n, '\n', __stream);
```