### PR TITLE
uses the recommended CI configs for node addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,62 @@
+language: c++
+compiler:
+  - clang
+  - gcc
+# For Linux, use an Ubuntu 14 image
+dist: trusty
 os:
   - linux
   - osx
+env:
+  global:
+    # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+    - NVS_VERSION=1.4.2
+  matrix:
+    - NODEJS_VERSION=node/4
+    - NODEJS_VERSION=node/6
+    - NODEJS_VERSION=node/8
+    - NODEJS_VERSION=node/9
+    - NODEJS_VERSION=node/10
+    - NODEJS_VERSION=node/12
+    - NODEJS_VERSION=nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: NODEJS_VERSION=nightly
 sudo: false
-language: cpp
+cache:
+  directories:
+    - node_modules
+    - $HOME/.npm
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
-notifications:
-  email: false
-env:
-  matrix:
-  - TRAVIS_NODE_VERSION="0.10"
-  - TRAVIS_NODE_VERSION="0.12"
-  - TRAVIS_NODE_VERSION="4"
-  - TRAVIS_NODE_VERSION="6"
-  - TRAVIS_NODE_VERSION="7"
-  - TRAVIS_NODE_VERSION="8"
-install:
-  - "rm -rf ~/.nvm && mkdir -p ~/.nvm && curl -sL `curl -sI https://github.com/creationix/nvm/releases/latest|sed -En 's/^Location: (.+)\\/releases\\/tag\\/(.+)/\\1\\/tarball\\/\\2/p'|tr -d '\r\n'`|tar zx --strip=1 -C ~/.nvm && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION"
+      - g++-4.9
+before_install:
+  # coveralls
+  - pip2 install --user cpp-coveralls
+  # compilers
+  - if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-4.9" CC="gcc-4.9" AR="gcc-ar-4.9" RANLIB="gcc-ranlib-4.9" NM="gcc-nm-4.9" ; fi
+  - if [ "$CXX" = "clang++" ]; then export NPMOPT=--clang=1 ; fi
+  - export CFLAGS="$CFLAGS -O3 --coverage" LDFLAGS="$LDFLAGS --coverage"
+  - echo "CFLAGS=\"$CFLAGS\" LDFLAGS=\"$LDFLAGS\""
+  # nvs
+  - git clone --branch v$NVS_VERSION --depth 1 https://github.com/jasongin/nvs ~/.nvs
+  - . ~/.nvs/nvs.sh
+  - nvs --version
+  # node.js
+  - nvs add $NODEJS_VERSION
+  - nvs use $NODEJS_VERSION
+  - node --version
   - npm --version
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; export CC=gcc-4.8; fi
-  - $CXX --version
-  - npm install
-script: npm test
+install:
+  - npm install $NPMOPT
+script:
+  # Travis CI sets NVM_NODEJS_ORG_MIRROR, but it makes node-gyp fail to download headers for nightly builds.
+  - unset NVM_NODEJS_ORG_MIRROR
+
+  - npm test $NPMOPT
+after_success:
+  - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,45 @@
-# http://www.appveyor.com/docs/appveyor-yml
-
-# Test against these versions of Node.js.
 environment:
+  # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+  NVS_VERSION: 1.4.2
+  fast_finish: true
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "4"
-    - nodejs_version: "6"
-    - nodejs_version: "7"
-    - nodejs_version: "8"
+    - NODEJS_VERSION: node/4
+    - NODEJS_VERSION: node/6
+    - NODEJS_VERSION: node/8
+    - NODEJS_VERSION: node/9
+    - NODEJS_VERSION: node/10
+    - NODEJS_VERSION: node/12
+    - NODEJS_VERSION: nightly
 
-# Install scripts. (runs after repo cloning)
+matrix:
+  fast_finish: true
+  allow_failures:
+    - NODEJS_VERSION: nightly
+
+platform:
+  - x86
+  - x64
+
 install:
-  # Get the latest stable version of Node
-  - ps: Install-Product node $env:nodejs_version
-  # Typical npm stuff.
-  - IF %nodejs_version% LSS 1 npm -g install npm@1.4.4
-  - IF %nodejs_version% LSS 1 set PATH=%APPDATA%\npm;%PATH%
-  - set CL=-DDELAYIMP_INSECURE_WRITABLE_HOOKS
+  # nvs
+  - git clone --branch v%NVS_VERSION% --depth 1 https://github.com/jasongin/nvs %LOCALAPPDATA%\nvs
+  - set PATH=%LOCALAPPDATA%\nvs;%PATH%
+  - nvs --version
+  # node.js
+  - nvs add %NODEJS_VERSION%/%PLATFORM%
+  - nvs use %NODEJS_VERSION%/%PLATFORM%
+  - node --version
+  - node -p process.arch
+  - npm --version
+  # app
   - npm install
 
-# Post-install test scripts.
 test_script:
-  # Output useful info for debugging.
-  - node --version
-  - npm --version
-  # run tests
   - npm test
 
-# Don't actually build.
 build: off
 
-# Set build version format here instead of in the admin panel.
 version: "{build}"
+
+cache:
+  - node_modules


### PR DESCRIPTION
The current travis config always fails and the appveyor config doesn't check recent version of NodeJS. This uses sample config for node addons.